### PR TITLE
Remove NoneType in results preprocessing

### DIFF
--- a/utils/load_data_sets.py
+++ b/utils/load_data_sets.py
@@ -88,6 +88,10 @@ class DataSet(object):
     @staticmethod
     def from_positions_w_context(positions_w_context, is_test=False, extract_move_prob=False):
         positions, next_moves, results = zip(*positions_w_context)
+
+        # Remove None types to prevent error in wrt_result
+        results = [i for i in results if i.result is not None]
+
         extracted_features = bulk_extract_features(positions)
         if extract_move_prob:
             encoded_moves = np.asarray(next_moves)


### PR DESCRIPTION
None types in results for preprocessing will result in an error when trying to return. Filtering out the None types beforehand appears to fix this, and preprocessing - alongside #17 - continues to actually write now.